### PR TITLE
Timers fixes

### DIFF
--- a/crates/javy/src/apis/timers/mod.rs
+++ b/crates/javy/src/apis/timers/mod.rs
@@ -61,10 +61,10 @@ impl TimerQueue {
             .duration_since(UNIX_EPOCH)
             .unwrap()
             .as_millis() as u64;
-        
+
         let id = self.next_id;
         self.next_id += 1;
-        
+
         let timer = Timer {
             id,
             // For delay=0, set fire_time to current time to ensure immediate availability
@@ -72,7 +72,7 @@ impl TimerQueue {
             callback,
             interval_ms: None,
         };
-        
+
         self.timers.push(timer);
         id
     }
@@ -82,10 +82,10 @@ impl TimerQueue {
             .duration_since(UNIX_EPOCH)
             .unwrap()
             .as_millis() as u64;
-        
+
         let id = self.next_id;
         self.next_id += 1;
-        
+
         let timer = Timer {
             id,
             // For delay=0, set fire_time to current time to ensure immediate availability
@@ -93,7 +93,7 @@ impl TimerQueue {
             callback,
             interval_ms: Some(delay_ms),
         };
-        
+
         self.timers.push(timer);
         id
     }
@@ -104,14 +104,14 @@ impl TimerQueue {
                 .duration_since(UNIX_EPOCH)
                 .unwrap()
                 .as_millis() as u64;
-            
+
             let new_timer = Timer {
                 id: timer.id,
                 fire_time: if interval_ms == 0 { now } else { now + interval_ms as u64 },
                 callback: timer.callback,
                 interval_ms: timer.interval_ms,
             };
-            
+
             self.timers.push(new_timer);
         }
     }
@@ -127,9 +127,9 @@ impl TimerQueue {
             .duration_since(UNIX_EPOCH)
             .unwrap()
             .as_millis() as u64;
-        
+
         let mut expired = Vec::new();
-        
+
         while let Some(timer) = self.timers.peek() {
             if timer.fire_time <= now {
                 expired.push(self.timers.pop().unwrap());
@@ -137,7 +137,7 @@ impl TimerQueue {
                 break;
             }
         }
-        
+
         expired
     }
 
@@ -146,67 +146,109 @@ impl TimerQueue {
     }
 }
 
-static TIMER_QUEUE: OnceLock<Arc<Mutex<TimerQueue>>> = OnceLock::new();
-
-fn get_timer_queue() -> &'static Arc<Mutex<TimerQueue>> {
-    TIMER_QUEUE.get_or_init(|| Arc::new(Mutex::new(TimerQueue::new())))
+pub struct TimersRuntime {
+    queue: Arc<Mutex<TimerQueue>>,
 }
 
-/// Register timer functions on the global object
-pub(crate) fn register(this: Ctx<'_>) -> Result<()> {
-    let globals = this.globals();
+impl TimersRuntime {
+    pub fn new() -> Self {
+        Self {
+            queue: Arc::new(Mutex::new(TimerQueue::new())),
+        }
+    }
 
-    globals.set(
-        "setTimeout",
-        Function::new(
-            this.clone(),
-            MutFn::new(move |cx, args| {
-                let (cx, args) = hold_and_release!(cx, args);
-                set_timeout(hold!(cx.clone(), args)).map_err(|e| to_js_error(cx, e))
-            }),
-        )?,
-    )?;
+    /// Register timer functions on the global object
+    pub fn register_globals(&self, this: Ctx<'_>) -> Result<()> {
+        let globals = this.globals();
 
-    globals.set(
-        "clearTimeout",
-        Function::new(
-            this.clone(),
-            MutFn::new(move |cx, args| {
-                let (cx, args) = hold_and_release!(cx, args);
-                clear_timeout(hold!(cx.clone(), args)).map_err(|e| to_js_error(cx, e))
-            }),
-        )?,
-    )?;
+        let queue = self.queue.clone();
+        globals.set(
+            "setTimeout",
+            Function::new(
+                this.clone(),
+                MutFn::new(move |cx, args| {
+                    let (cx, args) = hold_and_release!(cx, args);
+                    set_timeout(queue.clone(),hold!(cx.clone(), args)).map_err(|e| to_js_error(cx, e))
+                }),
+            )?,
+        )?;
 
-    globals.set(
-        "setInterval",
-        Function::new(
-            this.clone(),
-            MutFn::new(move |cx, args| {
-                let (cx, args) = hold_and_release!(cx, args);
-                set_interval(hold!(cx.clone(), args)).map_err(|e| to_js_error(cx, e))
-            }),
-        )?,
-    )?;
+        let queue = self.queue.clone();
+        globals.set(
+            "clearTimeout",
+            Function::new(
+                this.clone(),
+                MutFn::new(move |cx, args| {
+                    let (cx, args) = hold_and_release!(cx, args);
+                    clear_timeout(queue.clone(), hold!(cx.clone(), args)).map_err(|e| to_js_error(cx, e))
+                }),
+            )?,
+        )?;
 
-    globals.set(
-        "clearInterval",
-        Function::new(
-            this.clone(),
-            MutFn::new(move |cx, args| {
-                let (cx, args) = hold_and_release!(cx, args);
-                clear_interval(hold!(cx.clone(), args)).map_err(|e| to_js_error(cx, e))
-            }),
-        )?,
-    )?;
+        let queue = self.queue.clone();
+        globals.set(
+            "setInterval",
+            Function::new(
+                this.clone(),
+                MutFn::new(move |cx, args| {
+                    let (cx, args) = hold_and_release!(cx, args);
+                    set_interval(queue.clone(), hold!(cx.clone(), args)).map_err(|e| to_js_error(cx, e))
+                }),
+            )?,
+        )?;
 
-    Ok(())
+        let queue = self.queue.clone();
+        globals.set(
+            "clearInterval",
+            Function::new(
+                this.clone(),
+                MutFn::new(move |cx, args| {
+                    let (cx, args) = hold_and_release!(cx, args);
+                    clear_interval(queue.clone(), hold!(cx.clone(), args)).map_err(|e| to_js_error(cx, e))
+                }),
+            )?,
+        )?;
+
+        Ok(())
+    }
+
+    /// Process expired timers - should be called by the event loop
+    pub fn process_timers(&self, ctx: Ctx<'_>) -> Result<()> {
+        let mut queue = self.queue.lock().unwrap();
+        let expired_timers = queue.get_expired_timers();
+
+        // Separate intervals that need rescheduling
+        let (intervals, timeouts): (Vec<_>, Vec<_>) = expired_timers.into_iter()
+            .partition(|timer| timer.interval_ms.is_some());
+
+        // Reschedule intervals before releasing the lock
+        for interval in &intervals {
+            queue.reschedule_interval(interval.clone());
+        }
+
+        drop(queue); // Release lock before executing JavaScript
+
+        // Execute all timer callbacks (both timeouts and intervals)
+        for timer in timeouts.into_iter().chain(intervals.into_iter()) {
+            if let Err(e) = ctx.eval::<(), _>(timer.callback.as_str()) {
+                eprintln!("Timer callback error: {}", e);
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Check if there are pending timers
+    pub fn has_pending_timers(&self) -> bool {
+        let queue = self.queue.lock().unwrap();
+        queue.has_pending_timers()
+    }
 }
 
-fn set_timeout<'js>(args: Args<'js>) -> Result<Value<'js>> {
+fn set_timeout<'js>(queue: Arc<Mutex<TimerQueue>>, args: Args<'js>) -> Result<Value<'js>> {
     let (ctx, args) = args.release();
     let args = args.into_inner();
-    
+
     if args.is_empty() {
         return Err(anyhow!("setTimeout requires at least 1 argument"));
     }
@@ -227,32 +269,34 @@ fn set_timeout<'js>(args: Args<'js>) -> Result<Value<'js>> {
         0
     };
 
-    let mut queue = get_timer_queue().lock().unwrap();
+    let mut queue = queue.lock().unwrap();
     let timer_id = queue.add_timer(delay_ms, callback_str);
-    
+    drop(queue);
+
     Ok(Value::new_int(ctx, timer_id as i32))
 }
 
-fn clear_timeout<'js>(args: Args<'js>) -> Result<Value<'js>> {
+fn clear_timeout<'js>(queue: Arc<Mutex<TimerQueue>>, args: Args<'js>) -> Result<Value<'js>> {
     let (ctx, args) = args.release();
     let args = args.into_inner();
-    
+
     if args.is_empty() {
         return Ok(Value::new_undefined(ctx));
     }
 
     let timer_id = args[0].as_number().unwrap_or(0.0) as u32;
-    
-    let mut queue = get_timer_queue().lock().unwrap();
+
+    let mut queue = queue.lock().unwrap();
     queue.remove_timer(timer_id);
-    
+    drop(queue);
+
     Ok(Value::new_undefined(ctx))
 }
 
-fn set_interval<'js>(args: Args<'js>) -> Result<Value<'js>> {
+fn set_interval<'js>(queue: Arc<Mutex<TimerQueue>>, args: Args<'js>) -> Result<Value<'js>> {
     let (ctx, args) = args.release();
     let args = args.into_inner();
-    
+
     if args.is_empty() {
         return Err(anyhow!("setInterval requires at least 1 argument"));
     }
@@ -273,58 +317,28 @@ fn set_interval<'js>(args: Args<'js>) -> Result<Value<'js>> {
         0
     };
 
-    let mut queue = get_timer_queue().lock().unwrap();
+    let mut queue = queue.lock().unwrap();
     let timer_id = queue.add_interval(interval_ms, callback_str);
-    
+    drop(queue);
+
     Ok(Value::new_int(ctx, timer_id as i32))
 }
 
-fn clear_interval<'js>(args: Args<'js>) -> Result<Value<'js>> {
+fn clear_interval<'js>(queue: Arc<Mutex<TimerQueue>>, args: Args<'js>) -> Result<Value<'js>> {
     let (ctx, args) = args.release();
     let args = args.into_inner();
-    
+
     if args.is_empty() {
         return Ok(Value::new_undefined(ctx));
     }
 
     let timer_id = args[0].as_number().unwrap_or(0.0) as u32;
-    
-    let mut queue = get_timer_queue().lock().unwrap();
+
+    let mut queue = queue.lock().unwrap();
     queue.remove_timer(timer_id);
-    
+    drop(queue);
+
     Ok(Value::new_undefined(ctx))
-}
-
-/// Process expired timers - should be called by the event loop
-pub fn process_timers(ctx: Ctx<'_>) -> Result<()> {
-    let mut queue = get_timer_queue().lock().unwrap();
-    let expired_timers = queue.get_expired_timers();
-    
-    // Separate intervals that need rescheduling
-    let (intervals, timeouts): (Vec<_>, Vec<_>) = expired_timers.into_iter()
-        .partition(|timer| timer.interval_ms.is_some());
-    
-    // Reschedule intervals before releasing the lock
-    for interval in &intervals {
-        queue.reschedule_interval(interval.clone());
-    }
-    
-    drop(queue); // Release lock before executing JavaScript
-    
-    // Execute all timer callbacks (both timeouts and intervals)
-    for timer in timeouts.into_iter().chain(intervals.into_iter()) {
-        if let Err(e) = ctx.eval::<(), _>(timer.callback.as_str()) {
-            eprintln!("Timer callback error: {}", e);
-        }
-    }
-    
-    Ok(())
-}
-
-/// Check if there are pending timers
-pub fn has_pending_timers() -> bool {
-    let queue = get_timer_queue().lock().unwrap();
-    queue.has_pending_timers()
 }
 
 #[cfg(test)]
@@ -336,22 +350,22 @@ mod tests {
     #[test]
     fn test_timer_queue() {
         let mut queue = TimerQueue::new();
-        
+
         // Add some timers
         let id1 = queue.add_timer(100, "console.log('timer1')".to_string());
         let id2 = queue.add_timer(50, "console.log('timer2')".to_string());
         let id3 = queue.add_timer(200, "console.log('timer3')".to_string());
-        
+
         assert_eq!(id1, 1);
         assert_eq!(id2, 2);
         assert_eq!(id3, 3);
-        
+
         assert!(queue.has_pending_timers());
-        
+
         // Remove a timer
         assert!(queue.remove_timer(id2));
         assert!(!queue.remove_timer(999)); // Non-existent timer
-        
+
         assert!(queue.has_pending_timers());
     }
 
@@ -361,18 +375,16 @@ mod tests {
         config.timers(true);
         let runtime = Runtime::new(config)?;
         runtime.context().with(|cx| {
-            register(cx.clone())?;
-            
             // Check that setTimeout is available
             let result: Value = cx.eval("typeof setTimeout")?;
             let type_str = val_to_string(&cx, result)?;
             assert_eq!(type_str, "function");
-            
+
             // Check that clearTimeout is available
             let result: Value = cx.eval("typeof clearTimeout")?;
             let type_str = val_to_string(&cx, result)?;
             assert_eq!(type_str, "function");
-            
+
             Ok::<_, Error>(())
         })?;
         Ok(())
@@ -384,18 +396,16 @@ mod tests {
         config.timers(true);
         let runtime = Runtime::new(config)?;
         runtime.context().with(|cx| {
-            register(cx.clone())?;
-            
             // Test setTimeout with string callback
             let result: Value = cx.eval("setTimeout('1+1', 100)")?;
             let timer_id = result.as_number().unwrap() as i32;
             assert!(timer_id > 0);
-            
-            // Test setTimeout with function callback  
+
+            // Test setTimeout with function callback
             let result: Value = cx.eval("setTimeout(function() { return 42; }, 50)")?;
             let timer_id2 = result.as_number().unwrap() as i32;
             assert!(timer_id2 > timer_id);
-            
+
             Ok::<_, Error>(())
         })?;
         Ok(())
@@ -407,13 +417,11 @@ mod tests {
         config.timers(true);
         let runtime = Runtime::new(config)?;
         runtime.context().with(|cx| {
-            register(cx.clone())?;
-            
             // Create a timer and clear it
             let result: Value = cx.eval("const id = setTimeout('console.log(\"test\")', 1000); clearTimeout(id); id")?;
             let timer_id = result.as_number().unwrap() as i32;
             assert!(timer_id > 0);
-            
+
             Ok::<_, Error>(())
         })?;
         Ok(())
@@ -421,66 +429,61 @@ mod tests {
 
     #[test]
     fn test_timer_execution() -> Result<()> {
-        // Clear any existing timers from other tests
-        {
-            let mut queue = get_timer_queue().lock().unwrap();
-            queue.timers.clear();
-        }
-        
         let mut config = Config::default();
         config.timers(true);
         let runtime = Runtime::new(config)?;
+
+        // Use a unique variable name to avoid interference between tests
+        let unique_var = format!("timerExecuted_{}", std::process::id());
+        let timer_code = format!("globalThis.{} = false; setTimeout('globalThis.{} = true', 0)", unique_var, unique_var);
+
         runtime.context().with(|cx| {
-            register(cx.clone())?;
-            
-            // Use a unique variable name to avoid interference between tests
-            let unique_var = format!("timerExecuted_{}", std::process::id());
-            let timer_code = format!("globalThis.{} = false; setTimeout('globalThis.{} = true', 0)", unique_var, unique_var);
             cx.eval::<(), _>(timer_code.as_str())?;
-            
-            // Process timers immediately without sleep - they should be available
-            process_timers(cx.clone())?;
-            
+            Ok::<_, Error>(())
+        })?;
+
+        // Process timers immediately without sleep - they should be available
+        runtime.resolve_pending_jobs()?;
+
+        runtime.context().with(|cx| {
             // Check if timer was executed
             let check_code = format!("globalThis.{}", unique_var);
             let result: Value = cx.eval(check_code.as_str())?;
-            
+
             assert!(result.as_bool().unwrap_or(false));
-            
+
             Ok::<_, Error>(())
         })?;
+
         Ok(())
     }
 
     #[test]
     fn test_timer_with_delay() -> Result<()> {
-        // Clear any existing timers from other tests
-        {
-            let mut queue = get_timer_queue().lock().unwrap();
-            queue.timers.clear();
-        }
-        
         let mut config = Config::default();
         config.timers(true);
         let runtime = Runtime::new(config)?;
+
+        // Use unique variable name to avoid interference between tests
+        let unique_var = format!("delayedTimer_{}", std::process::id());
+
+        // Set a timer with a delay that shouldn't fire immediately
+        let timer_code = format!("globalThis.{} = false; setTimeout('globalThis.{} = true', 1000)", unique_var, unique_var);
+
         runtime.context().with(|cx| {
-            register(cx.clone())?;
-            
-            // Use unique variable name to avoid interference between tests
-            let unique_var = format!("delayedTimer_{}", std::process::id());
-            
-            // Set a timer with a delay that shouldn't fire immediately
-            let timer_code = format!("globalThis.{} = false; setTimeout('globalThis.{} = true', 1000)", unique_var, unique_var);
             cx.eval::<(), _>(timer_code.as_str())?;
-            
-            // Process timers immediately - should not execute
-            process_timers(cx.clone())?;
-            
+            Ok::<_, Error>(())
+        })?;
+
+        // Process timers immediately - should not execute
+        runtime.resolve_pending_jobs()?;
+
+        runtime.context().with(|cx| {
             // Check if timer was NOT executed
             let check_code = format!("globalThis.{}", unique_var);
             let result: Value = cx.eval(check_code.as_str())?;
             assert!(!result.as_bool().unwrap_or(true));
-            
+
             Ok::<_, Error>(())
         })?;
         Ok(())
@@ -488,23 +491,16 @@ mod tests {
 
     #[test]
     fn test_multiple_timers() -> Result<()> {
-        // Clear any existing timers from other tests
-        {
-            let mut queue = get_timer_queue().lock().unwrap();
-            queue.timers.clear();
-        }
-        
         let mut config = Config::default();
         config.timers(true);
         let runtime = Runtime::new(config)?;
+
+        // Use unique variable names to avoid interference between tests
+        let unique_id = std::process::id();
+        let timer1_var = format!("timer1_{}", unique_id);
+        let timer2_var = format!("timer2_{}", unique_id);
+
         runtime.context().with(|cx| {
-            register(cx.clone())?;
-            
-            // Use unique variable names to avoid interference between tests
-            let unique_id = std::process::id();
-            let timer1_var = format!("timer1_{}", unique_id);
-            let timer2_var = format!("timer2_{}", unique_id);
-            
             // Set multiple timers
             let timer_code = format!("
                 globalThis.{} = false;
@@ -513,10 +509,14 @@ mod tests {
                 setTimeout('globalThis.{} = true', 0);
             ", timer1_var, timer2_var, timer1_var, timer2_var);
             cx.eval::<(), _>(timer_code.as_str())?;
-            
-            // Process timers
-            process_timers(cx.clone())?;
-            
+            Ok::<_, Error>(())
+        })?;
+
+
+        // Process timers
+        runtime.resolve_pending_jobs()?;
+
+        runtime.context().with(|cx| {
             // Check if both timers were executed
             let check1_code = format!("globalThis.{}", timer1_var);
             let check2_code = format!("globalThis.{}", timer2_var);
@@ -524,7 +524,7 @@ mod tests {
             let result2: Value = cx.eval(check2_code.as_str())?;
             assert!(result1.as_bool().unwrap_or(false));
             assert!(result2.as_bool().unwrap_or(false));
-            
+
             Ok::<_, Error>(())
         })?;
         Ok(())
@@ -532,37 +532,34 @@ mod tests {
 
     #[test]
     fn test_clear_timeout_removes_timer() -> Result<()> {
-        // Clear any existing timers from other tests
-        {
-            let mut queue = get_timer_queue().lock().unwrap();
-            queue.timers.clear();
-        }
-        
         let mut config = Config::default();
         config.timers(true);
         let runtime = Runtime::new(config)?;
+
+        // Use unique variable name to avoid interference between tests
+        let unique_var = format!("clearedTimer_{}", std::process::id());
+
+        // Set a timer and immediately clear it
+        let timer_code = format!("
+            globalThis.{} = false;
+            const id = setTimeout('globalThis.{} = true', 0);
+            clearTimeout(id);
+        ", unique_var, unique_var);
+
         runtime.context().with(|cx| {
-            register(cx.clone())?;
-            
-            // Use unique variable name to avoid interference between tests
-            let unique_var = format!("clearedTimer_{}", std::process::id());
-            
-            // Set a timer and immediately clear it
-            let timer_code = format!("
-                globalThis.{} = false;
-                const id = setTimeout('globalThis.{} = true', 0);
-                clearTimeout(id);
-            ", unique_var, unique_var);
             cx.eval::<(), _>(timer_code.as_str())?;
-            
-            // Process timers
-            process_timers(cx.clone())?;
-            
+            Ok::<_, Error>(())
+        })?;
+
+        // Process timers
+        runtime.resolve_pending_jobs()?;
+
+        runtime.context().with(|cx| {
             // Check if timer was NOT executed
             let check_code = format!("globalThis.{}", unique_var);
             let result: Value = cx.eval(check_code.as_str())?;
             assert!(!result.as_bool().unwrap_or(true));
-            
+
             Ok::<_, Error>(())
         })?;
         Ok(())
@@ -570,27 +567,20 @@ mod tests {
 
     #[test]
     fn test_has_pending_timers() -> Result<()> {
-        // Clear any existing timers from other tests and verify clean state
-        {
-            let mut queue = get_timer_queue().lock().unwrap();
-            queue.timers.clear();
-        }
-        
-        // Initially no pending timers
-        assert!(!has_pending_timers());
-        
         let mut config = Config::default();
         config.timers(true);
         let runtime = Runtime::new(config)?;
+
+        // Initially no pending timers
+        assert!(!runtime.has_pending_timers());
+
         runtime.context().with(|cx| {
-            register(cx.clone())?;
-            
             // Add a timer
             cx.eval::<(), _>("setTimeout('console.log(\"test\")', 1000)")?;
-            
+
             // Should have pending timers
-            assert!(has_pending_timers());
-            
+            assert!(runtime.has_pending_timers());
+
             Ok::<_, Error>(())
         })?;
         Ok(())
@@ -598,26 +588,18 @@ mod tests {
 
     #[test]
     fn test_set_interval_basic() -> Result<()> {
-        // Clear any existing timers from other tests
-        {
-            let mut queue = get_timer_queue().lock().unwrap();
-            queue.timers.clear();
-        }
-        
         let mut config = Config::default();
         config.timers(true);
         let runtime = Runtime::new(config)?;
         runtime.context().with(|cx| {
-            register(cx.clone())?;
-            
             // Test setInterval with string callback
             let result: Value = cx.eval("setInterval('1+1', 100)")?;
             let interval_id = result.as_number().unwrap() as i32;
             assert!(interval_id > 0);
-            
+
             // Should have pending timers
-            assert!(has_pending_timers());
-            
+            assert!(runtime.has_pending_timers());
+
             Ok::<_, Error>(())
         })?;
         Ok(())
@@ -625,23 +607,15 @@ mod tests {
 
     #[test]
     fn test_clear_interval() -> Result<()> {
-        // Clear any existing timers from other tests
-        {
-            let mut queue = get_timer_queue().lock().unwrap();
-            queue.timers.clear();
-        }
-        
         let mut config = Config::default();
         config.timers(true);
         let runtime = Runtime::new(config)?;
         runtime.context().with(|cx| {
-            register(cx.clone())?;
-            
             // Create an interval and clear it
             let result: Value = cx.eval("const id = setInterval('console.log(\"test\")', 1000); clearInterval(id); id")?;
             let interval_id = result.as_number().unwrap() as i32;
             assert!(interval_id > 0);
-            
+
             Ok::<_, Error>(())
         })?;
         Ok(())
@@ -649,36 +623,33 @@ mod tests {
 
     #[test]
     fn test_interval_execution_and_rescheduling() -> Result<()> {
-        // Clear any existing timers from other tests
-        {
-            let mut queue = get_timer_queue().lock().unwrap();
-            queue.timers.clear();
-        }
-        
         let mut config = Config::default();
         config.timers(true);
         let runtime = Runtime::new(config)?;
+
+        // Use unique variable name to avoid interference between tests
+        let unique_var = format!("intervalCount_{}", std::process::id());
+        let interval_code = format!("globalThis.{} = 0; setInterval('globalThis.{}++', 0)", unique_var, unique_var);
+
         runtime.context().with(|cx| {
-            register(cx.clone())?;
-            
-            // Use unique variable name to avoid interference between tests
-            let unique_var = format!("intervalCount_{}", std::process::id());
-            let interval_code = format!("globalThis.{} = 0; setInterval('globalThis.{}++', 0)", unique_var, unique_var);
             cx.eval::<(), _>(interval_code.as_str())?;
-            
-            // Process timers multiple times to test rescheduling
-            process_timers(cx.clone())?;
-            process_timers(cx.clone())?;
-            process_timers(cx.clone())?;
-            
+            Ok::<_, Error>(())
+        })?;
+
+        // Process timers multiple times to test rescheduling
+        runtime.resolve_pending_jobs()?;
+        runtime.resolve_pending_jobs()?;
+        runtime.resolve_pending_jobs()?;
+
+        runtime.context().with(|cx| {
             // Check if interval executed multiple times
             let check_code = format!("globalThis.{}", unique_var);
             let result: Value = cx.eval(check_code.as_str())?;
             let count = result.as_number().unwrap_or(0.0) as i32;
-            
+
             // Should have executed at least twice (showing it's repeating)
             assert!(count >= 2, "Interval should have executed multiple times, got {}", count);
-            
+
             Ok::<_, Error>(())
         })?;
         Ok(())
@@ -686,40 +657,37 @@ mod tests {
 
     #[test]
     fn test_clear_interval_stops_repetition() -> Result<()> {
-        // Clear any existing timers from other tests
-        {
-            let mut queue = get_timer_queue().lock().unwrap();
-            queue.timers.clear();
-        }
-        
         let mut config = Config::default();
         config.timers(true);
         let runtime = Runtime::new(config)?;
+
+        // Use unique variable name to avoid interference between tests
+        let unique_var = format!("clearedIntervalCount_{}", std::process::id());
+
         runtime.context().with(|cx| {
-            register(cx.clone())?;
-            
-            // Use unique variable name to avoid interference between tests
-            let unique_var = format!("clearedIntervalCount_{}", std::process::id());
             let interval_code = format!("
                 globalThis.{} = 0;
                 const id = setInterval('globalThis.{}++', 0);
                 clearInterval(id);
             ", unique_var, unique_var);
             cx.eval::<(), _>(interval_code.as_str())?;
-            
-            // Process timers multiple times
-            process_timers(cx.clone())?;
-            process_timers(cx.clone())?;
-            process_timers(cx.clone())?;
-            
+            Ok::<_, Error>(())
+        })?;
+
+        // Process timers multiple times
+        runtime.resolve_pending_jobs()?;
+        runtime.resolve_pending_jobs()?;
+        runtime.resolve_pending_jobs()?;
+
+        runtime.context().with(|cx| {
             // Check that interval was NOT executed
             let check_code = format!("globalThis.{}", unique_var);
             let result: Value = cx.eval(check_code.as_str())?;
             let count = result.as_number().unwrap_or(-1.0) as i32;
-            
+
             // Should still be 0 (not executed)
             assert_eq!(count, 0, "Cleared interval should not execute, got {}", count);
-            
+
             Ok::<_, Error>(())
         })?;
         Ok(())
@@ -727,23 +695,16 @@ mod tests {
 
     #[test]
     fn test_interval_and_timeout_coexistence() -> Result<()> {
-        // Clear any existing timers from other tests
-        {
-            let mut queue = get_timer_queue().lock().unwrap();
-            queue.timers.clear();
-        }
-        
         let mut config = Config::default();
         config.timers(true);
         let runtime = Runtime::new(config)?;
+
+        // Use unique variable names
+        let unique_id = std::process::id();
+        let timeout_var = format!("timeoutExecuted_{}", unique_id);
+        let interval_var = format!("intervalCount_{}", unique_id);
+
         runtime.context().with(|cx| {
-            register(cx.clone())?;
-            
-            // Use unique variable names
-            let unique_id = std::process::id();
-            let timeout_var = format!("timeoutExecuted_{}", unique_id);
-            let interval_var = format!("intervalCount_{}", unique_id);
-            
             // Set timeout first, then interval - both with 0 delay
             let timer_code = format!("
                 globalThis.{} = false;
@@ -752,31 +713,39 @@ mod tests {
                 setInterval('globalThis.{}++', 0);
             ", timeout_var, interval_var, timeout_var, interval_var);
             cx.eval::<(), _>(timer_code.as_str())?;
-            
-            // Process timers first time - should execute both timeout and first interval
-            process_timers(cx.clone())?;
-            
-            // Check both timeout and interval results
-            let timeout_check = format!("globalThis.{}", timeout_var);
-            let interval_check = format!("globalThis.{}", interval_var);
-            
+            Ok::<_, Error>(())
+        })?;
+
+        // Process timers first time - should execute both timeout and first interval
+        runtime.resolve_pending_jobs()?;
+
+        // Check both timeout and interval results
+        let timeout_check = format!("globalThis.{}", timeout_var);
+        let interval_check = format!("globalThis.{}", interval_var);
+
+        runtime.context().with(|cx| {
             let timeout_result: Value = cx.eval(timeout_check.as_str())?;
             let interval_result: Value = cx.eval(interval_check.as_str())?;
-            
+
             assert!(timeout_result.as_bool().unwrap_or(false), "Timeout should have executed");
             assert!(interval_result.as_number().unwrap_or(0.0) as i32 >= 1, "Interval should have executed at least once");
-            
-            // Process timers again to verify interval repeats (timeout shouldn't run again)
-            process_timers(cx.clone())?;
+
+            Ok::<_, Error>(())
+        })?;
+
+        // Process timers again to verify interval repeats (timeout shouldn't run again)
+        runtime.resolve_pending_jobs()?;
+
+        runtime.context().with(|cx| {
             let interval_result2: Value = cx.eval(interval_check.as_str())?;
             let timeout_result2: Value = cx.eval(timeout_check.as_str())?;
-            
+
             // Timeout should still be true (unchanged), interval should have incremented
             assert!(timeout_result2.as_bool().unwrap_or(false), "Timeout should remain executed");
             assert!(interval_result2.as_number().unwrap_or(0.0) as i32 >= 2, "Interval should have executed multiple times");
-            
+
             Ok::<_, Error>(())
         })?;
         Ok(())
     }
-} 
+}

--- a/crates/javy/src/apis/timers/queue.rs
+++ b/crates/javy/src/apis/timers/queue.rs
@@ -3,12 +3,18 @@ use std::{
     time::{SystemTime, UNIX_EPOCH},
 };
 
-/// Timer entry in the timer queue
 #[derive(Debug, Clone)]
+pub(super) enum TimerCallback {
+    Code(String),
+    Function,
+}
+
+/// Timer entry in the timer queue
+#[derive(Debug)]
 pub(super) struct Timer {
     pub id: u32,
     pub fire_time: u64,           // milliseconds since UNIX epoch
-    pub callback: String,         // JavaScript code to execute
+    pub callback: TimerCallback,
     pub interval_ms: Option<u32>, // If Some(), this is a repeating timer
 }
 
@@ -52,7 +58,7 @@ impl TimerQueue {
         &mut self,
         delay_ms: u32,
         repeat: bool,
-        callback: String,
+        callback: TimerCallback,
         reuse_id: Option<u32>,
     ) -> u32 {
         let now = Self::now();
@@ -114,10 +120,14 @@ mod tests {
     fn test_timer_queue() {
         let mut queue = TimerQueue::new();
 
+        fn add_timer(delay_ms: u32, callback_code: &str, queue: &mut TimerQueue) -> u32 {
+            queue.add_timer(delay_ms, false, TimerCallback::Code(callback_code.to_string()), None)
+        }
+
         // Add some timers
-        let id1 = queue.add_timer(100, false, "console.log('timer1')".to_string(), None);
-        let id2 = queue.add_timer(50, false, "console.log('timer2')".to_string(), None);
-        let id3 = queue.add_timer(200, false, "console.log('timer3')".to_string(), None);
+        let id1 = add_timer(100, "console.log('timer1')", &mut queue);
+        let id2 = add_timer(50, "console.log('timer2')", &mut queue);
+        let id3 = add_timer(200, "console.log('timer3')", &mut queue);
 
         assert_eq!(id1, 1);
         assert_eq!(id2, 2);

--- a/crates/javy/src/apis/timers/queue.rs
+++ b/crates/javy/src/apis/timers/queue.rs
@@ -1,0 +1,134 @@
+use std::{
+    collections::BinaryHeap,
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+/// Timer entry in the timer queue
+#[derive(Debug, Clone)]
+pub(super) struct Timer {
+    pub id: u32,
+    pub fire_time: u64,           // milliseconds since UNIX epoch
+    pub callback: String,         // JavaScript code to execute
+    pub interval_ms: Option<u32>, // If Some(), this is a repeating timer
+}
+
+impl PartialEq for Timer {
+    fn eq(&self, other: &Self) -> bool {
+        self.fire_time == other.fire_time
+    }
+}
+
+impl Eq for Timer {}
+
+impl PartialOrd for Timer {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for Timer {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        // Reverse order for min-heap behavior
+        other.fire_time.cmp(&self.fire_time)
+    }
+}
+
+/// Global timer queue
+#[derive(Debug)]
+pub(super) struct TimerQueue {
+    timers: BinaryHeap<Timer>,
+    next_id: u32,
+}
+
+impl TimerQueue {
+    pub fn new() -> Self {
+        Self {
+            timers: BinaryHeap::new(),
+            next_id: 1,
+        }
+    }
+
+    pub fn add_timer(
+        &mut self,
+        delay_ms: u32,
+        repeat: bool,
+        callback: String,
+        reuse_id: Option<u32>,
+    ) -> u32 {
+        let now = Self::now();
+
+        let id = reuse_id.unwrap_or_else(|| {
+            let id = self.next_id;
+            self.next_id += 1;
+            id
+        });
+
+        let timer = Timer {
+            id,
+            fire_time: now + delay_ms as u64,
+            callback,
+            interval_ms: if repeat { Some(delay_ms) } else { None },
+        };
+
+        self.timers.push(timer);
+        id
+    }
+
+    pub fn remove_timer(&mut self, timer_id: u32) -> bool {
+        let original_len = self.timers.len();
+        self.timers.retain(|timer| timer.id != timer_id);
+        self.timers.len() != original_len
+    }
+
+    pub fn get_expired_timers(&mut self) -> Vec<Timer> {
+        let now = Self::now();
+        let mut expired = Vec::new();
+        while let Some(timer) = self.timers.peek() {
+            if timer.fire_time <= now {
+                expired.push(self.timers.pop().unwrap());
+            } else {
+                break;
+            }
+        }
+
+        expired
+    }
+
+    pub fn has_pending_timers(&self) -> bool {
+        !self.timers.is_empty()
+    }
+
+    fn now() -> u64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_millis() as u64
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_timer_queue() {
+        let mut queue = TimerQueue::new();
+
+        // Add some timers
+        let id1 = queue.add_timer(100, false, "console.log('timer1')".to_string(), None);
+        let id2 = queue.add_timer(50, false, "console.log('timer2')".to_string(), None);
+        let id3 = queue.add_timer(200, false, "console.log('timer3')".to_string(), None);
+
+        assert_eq!(id1, 1);
+        assert_eq!(id2, 2);
+        assert_eq!(id3, 3);
+
+        assert!(queue.has_pending_timers());
+
+        // Remove a timer
+        assert!(queue.remove_timer(id2));
+        assert!(!queue.remove_timer(999)); // Non-existent timer
+
+        assert!(queue.has_pending_timers());
+    }
+}

--- a/crates/javy/src/runtime.rs
+++ b/crates/javy/src/runtime.rs
@@ -39,7 +39,7 @@ pub struct Runtime {
     /// The inner QuickJS runtime representation.
     // Read above on the usage of `ManuallyDrop`.
     inner: ManuallyDrop<QRuntime>,
-    /// Whether timers are enabled
+    /// Timers runtime state, if enabled.
     timers: Option<TimersRuntime>,
 }
 

--- a/crates/javy/src/runtime.rs
+++ b/crates/javy/src/runtime.rs
@@ -3,7 +3,7 @@ use super::from_js_error;
 #[cfg(feature = "json")]
 use crate::apis::json;
 use crate::{
-    apis::{base64, console, random, stream_io, text_encoding, timers},
+    apis::{base64, console, random, stream_io, text_encoding, timers::TimersRuntime},
     config::{JSIntrinsics, JavyIntrinsics},
     Config,
 };
@@ -40,20 +40,24 @@ pub struct Runtime {
     // Read above on the usage of `ManuallyDrop`.
     inner: ManuallyDrop<QRuntime>,
     /// Whether timers are enabled
-    timers_enabled: bool,
+    timers: Option<TimersRuntime>,
 }
 
 impl Runtime {
     /// Creates a new [Runtime].
     pub fn new(config: Config) -> Result<Self> {
         let rt = ManuallyDrop::new(QRuntime::new()?);
-        let timers_enabled = config.intrinsics.contains(JSIntrinsics::TIMERS);
+        let timers = if config.intrinsics.contains(JSIntrinsics::TIMERS) {
+            Some(TimersRuntime::new())
+        } else {
+            None
+        };
 
-        let context = Self::build_from_config(&rt, config)?;
-        Ok(Self { inner: rt, context, timers_enabled })
+        let context = Self::build_from_config(&rt, config, &timers)?;
+        Ok(Self { inner: rt, context, timers })
     }
 
-    fn build_from_config(rt: &QRuntime, cfg: Config) -> Result<ManuallyDrop<Context>> {
+    fn build_from_config(rt: &QRuntime, cfg: Config, timers: &Option<TimersRuntime>) -> Result<ManuallyDrop<Context>> {
         let cfg = cfg.validate()?;
         let intrinsics = &cfg.intrinsics;
         let javy_intrinsics = &cfg.javy_intrinsics;
@@ -156,8 +160,8 @@ impl Runtime {
                     .expect("registering StreamIO functions to succeed");
             }
 
-            if intrinsics.contains(JSIntrinsics::TIMERS) {
-                timers::register(ctx.clone())
+            if let Some(timers) = timers {
+                timers.register_globals(ctx.clone())
                     .expect("registering timer APIs to succeed");
             }
         });
@@ -174,8 +178,8 @@ impl Runtime {
     pub fn resolve_pending_jobs(&self) -> Result<()> {
         // Process timers if enabled
         self.context.with(|ctx| {
-            if self.has_timers_enabled() {
-                timers::process_timers(ctx.clone()).unwrap_or_else(|e| {
+            if let Some(timers) = &self.timers {
+                timers.process_timers(ctx.clone()).unwrap_or_else(|e| {
                     eprintln!("Timer processing error: {}", e);
                 });
             }
@@ -200,18 +204,15 @@ impl Runtime {
     /// Returns true if there are pending jobs in the queue.
     pub fn has_pending_jobs(&self) -> bool {
         let has_js_jobs = self.inner.is_job_pending();
-        let has_timer_jobs = if self.has_timers_enabled() {
-            timers::has_pending_timers()
-        } else {
-            false
-        };
-        
-        has_js_jobs || has_timer_jobs
+        has_js_jobs || self.has_pending_timers()
     }
 
-    /// Returns true if timers are enabled for this runtime.
-    pub fn has_timers_enabled(&self) -> bool {
-        self.timers_enabled
+    pub fn has_pending_timers(&self) -> bool {
+        if let Some(timers) = &self.timers {
+            timers.has_pending_timers()
+        } else {
+            false
+        }
     }
 
     /// Compiles the given module to bytecode.


### PR DESCRIPTION
DISCLAIMER:
I have no expertise in the project and no expertise in rust, so it is rather experiment/exploration/playground.
I did not bother checking timers' specification, but it should be fine given the current goals.
Also, the implementation currently stores callback function in JS' `globals` which is not ideal, but I haven't found a way to do it on rust level (yet).

- [x] Don't use global variable for timers queue
  It seems, timer tests are not flaky now
- [x] Refine the code
- [x] Add support for function callbacks (and related test to cover)

## Description of the change

## Why am I making this change?

## Checklist

- [ ] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-plugin` do not require updating CHANGELOG files.
- [ ] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [ ] I've updated documentation including crate documentation if necessary.
